### PR TITLE
Make BetterSwerveKinematics.java consistently robot-relative

### DIFF
--- a/src/main/java/com/team3181/lib/swerve/BetterSwerveKinematics.java
+++ b/src/main/java/com/team3181/lib/swerve/BetterSwerveKinematics.java
@@ -187,7 +187,7 @@ public class BetterSwerveKinematics extends SwerveDriveKinematics {
 
             var omegaVector = trigThetaAngle.mult(accelVector);
 
-            double omega = omegaVector.get(1, 0) / speed;
+            double omega = (omegaVector.get(1, 0) / speed) - chassisSpeeds.omegaRadiansPerSecond;
             m_moduleStates[i] = new BetterSwerveModuleState(speed, angle, omega);
         }
 


### PR DESCRIPTION
BetterSwerveKinematics currently outputs robot-relative module angles and field-relative module angular rates.  Simple fix to make both be robot-relative.